### PR TITLE
IRQ: x86: Fix KVM irqchip_split initialization

### DIFF
--- a/x86/kvm.c
+++ b/x86/kvm.c
@@ -176,6 +176,16 @@ void kvm__arch_init(struct kvm *kvm)
 		ret = ioctl(kvm->vm_fd, KVM_CREATE_IRQCHIP);
 		if (ret < 0)
 			die_perror("KVM_CREATE_IRQCHIP ioctl");
+	} else {
+		struct kvm_enable_cap cap = {
+			.cap = KVM_CAP_SPLIT_IRQCHIP,
+			.flags = 0,
+			.args[0] = KVM_IOAPIC_NUM_PINS,
+		};
+		ret = ioctl(kvm->vm_fd, KVM_ENABLE_CAP, &cap);
+		if (ret < 0) {
+			die_perror("Could not enable split irqchip mode");
+		}
 	}
 }
 


### PR DESCRIPTION
According to KVM api (https://docs.kernel.org/virt/kvm/api.html), KVM_CAP_SPLIT_IRQCHIP should be enabled if the userspace VMM wishes to emulate the IOAPIC and PIC.